### PR TITLE
feat: add requestOptions to all requests

### DIFF
--- a/aircraft.go
+++ b/aircraft.go
@@ -10,20 +10,22 @@ import (
 
 type (
 	AircraftClient interface {
-		ListAircraft(ctx context.Context) *Iter[Aircraft]
-		GetAircraft(ctx context.Context, id string) (*Aircraft, error)
+		ListAircraft(ctx context.Context, requestOptions ...RequestOption) *Iter[Aircraft]
+		GetAircraft(ctx context.Context, id string, requestOptions ...RequestOption) (*Aircraft, error)
 	}
 )
 
-func (a *API) ListAircraft(ctx context.Context) *Iter[Aircraft] {
+func (a *API) ListAircraft(ctx context.Context, requestOptions ...RequestOption) *Iter[Aircraft] {
 	return newRequestWithAPI[ListAirportsParams, Aircraft](a).
 		Get("/air/aircraft").
+		WithOptions(requestOptions...).
 		Iter(ctx)
 }
 
-func (a *API) GetAircraft(ctx context.Context, id string) (*Aircraft, error) {
+func (a *API) GetAircraft(ctx context.Context, id string, requestOptions ...RequestOption) (*Aircraft, error) {
 	return newRequestWithAPI[EmptyPayload, Aircraft](a).
 		Getf("/air/aircraft/%s", id).
+		WithOptions(requestOptions...).
 		Single(ctx)
 }
 

--- a/airlines.go
+++ b/airlines.go
@@ -10,20 +10,22 @@ import (
 
 type (
 	AirlinesClient interface {
-		ListAirlines(ctx context.Context) *Iter[Airline]
-		GetAirline(ctx context.Context, id string) (*Airline, error)
+		ListAirlines(ctx context.Context, requestOptions ...RequestOption) *Iter[Airline]
+		GetAirline(ctx context.Context, id string, requestOptions ...RequestOption) (*Airline, error)
 	}
 )
 
-func (a *API) ListAirlines(ctx context.Context) *Iter[Airline] {
+func (a *API) ListAirlines(ctx context.Context, requestOptions ...RequestOption) *Iter[Airline] {
 	return newRequestWithAPI[EmptyPayload, Airline](a).
 		Get("/air/airlines").
+		WithOptions(requestOptions...).
 		Iter(ctx)
 }
 
-func (a *API) GetAirline(ctx context.Context, id string) (*Airline, error) {
+func (a *API) GetAirline(ctx context.Context, id string, requestOptions ...RequestOption) (*Airline, error) {
 	return newRequestWithAPI[EmptyPayload, Airline](a).
 		Getf("/air/airlines/%s", id).
+		WithOptions(requestOptions...).
 		Single(ctx)
 }
 

--- a/airports.go
+++ b/airports.go
@@ -11,8 +11,8 @@ import (
 
 type (
 	AirportsClient interface {
-		ListAirports(ctx context.Context, params ...ListAirportsParams) *Iter[Airport]
-		GetAirport(ctx context.Context, id string) (*Airport, error)
+		ListAirports(ctx context.Context, params []ListAirportsParams, requestOptions ...RequestOption) *Iter[Airport]
+		GetAirport(ctx context.Context, id string, requestOptions ...RequestOption) (*Airport, error)
 	}
 
 	ListAirportsParams struct {
@@ -20,16 +20,18 @@ type (
 	}
 )
 
-func (a *API) ListAirports(ctx context.Context, params ...ListAirportsParams) *Iter[Airport] {
+func (a *API) ListAirports(ctx context.Context, params []ListAirportsParams, requestOptions ...RequestOption) *Iter[Airport] {
 	return newRequestWithAPI[ListAirportsParams, Airport](a).
 		Get("/air/airports").
 		WithParams(normalizeParams(params)...).
+		WithOptions(requestOptions...).
 		Iter(ctx)
 }
 
-func (a *API) GetAirport(ctx context.Context, id string) (*Airport, error) {
+func (a *API) GetAirport(ctx context.Context, id string, requestOptions ...RequestOption) (*Airport, error) {
 	return newRequestWithAPI[EmptyPayload, Airport](a).
 		Getf("/air/airports/%s", id).
+		WithOptions(requestOptions...).
 		Single(ctx)
 }
 

--- a/airports_test.go
+++ b/airports_test.go
@@ -30,8 +30,10 @@ func TestListAirports(t *testing.T) {
 	ctx := context.TODO()
 
 	client := New("duffel_test_123")
-	iter := client.ListAirports(ctx, ListAirportsParams{
-		IATACountryCode: "GB",
+	iter := client.ListAirports(ctx, []ListAirportsParams{
+		{
+			IATACountryCode: "GB",
+		},
 	})
 
 	iter.Next()

--- a/client_test.go
+++ b/client_test.go
@@ -78,9 +78,7 @@ func TestClientRetry(t *testing.T) {
 			return err != nil
 		}),
 	)
-	data, err := client.CreateOfferRequest(ctx, OfferRequestInput{
-		ReturnOffers: true,
-	})
+	data, err := client.CreateOfferRequest(ctx, OfferRequestInput{ReturnOffers: true})
 	a.Error(err)
 	a.Nil(data)
 	a.Equal("duffel: An internal server error occurred. Please try again later.", err.Error())

--- a/examples/airports/main.go
+++ b/examples/airports/main.go
@@ -17,7 +17,7 @@ import (
 func main() {
 	ctx := context.Background()
 	client := duffel.New(os.Getenv("DUFFEL_TOKEN"))
-	iter := client.ListAirports(ctx, duffel.ListAirportsParams{
+	iter := client.ListAirports(ctx, []duffel.ListAirportsParams{
 		// IATACountryCode: "AU",
 	})
 

--- a/examples/e2e/main.go
+++ b/examples/e2e/main.go
@@ -53,7 +53,7 @@ func main() {
 	})
 	handleErr(err)
 
-	offersIter := client.ListOffers(ctx, data.ID)
+	offersIter := client.ListOffers(ctx, data.ID, nil)
 	var selectedOffer *duffel.Offer
 
 	allOffers, err := duffel.Collect(offersIter)

--- a/examples/offers/main.go
+++ b/examples/offers/main.go
@@ -208,8 +208,10 @@ func getOfferAction(c *cli.Context) error {
 	client := duffel.New(os.Getenv("DUFFEL_TOKEN"))
 	offerID := c.Args().First()
 
-	off, err := client.GetOffer(c.Context, offerID, duffel.GetOfferParams{
-		ReturnAvailableServices: true,
+	off, err := client.GetOffer(c.Context, offerID, []duffel.GetOfferParams{
+		{
+			ReturnAvailableServices: true,
+		},
 	})
 	if err != nil {
 		log.Printf("OfferID: %s", offerID)
@@ -278,9 +280,11 @@ func getOfferSeatsAction(c *cli.Context) error {
 func listOffersAction(c *cli.Context) error {
 	client := duffel.New(os.Getenv("DUFFEL_TOKEN"))
 	requestID := c.Args().First()
-	iter := client.ListOffers(c.Context, requestID, duffel.ListOffersParams{
-		MaxConnections: 1,
-		Sort:           duffel.ListOffersSortTotalAmount,
+	iter := client.ListOffers(c.Context, requestID, []duffel.ListOffersParams{
+		{
+			MaxConnections: 1,
+			Sort:           duffel.ListOffersSortTotalAmount,
+		},
 	})
 
 	for iter.Next() {

--- a/offers.go
+++ b/offers.go
@@ -8,20 +8,18 @@ import (
 	"context"
 	"fmt"
 	"net/url"
-	"strings"
 	"time"
 
 	"github.com/bojanz/currency"
 )
 
 const offerIDPrefix = "off_"
-const offerRequestIDPrefix = "orq_"
 
 type (
 	OfferClient interface {
-		UpdateOfferPassenger(ctx context.Context, offerRequestID, passengerID string, input PassengerUpdateInput) (*OfferRequestPassenger, error)
-		ListOffers(ctx context.Context, reqId string, options ...ListOffersParams) *Iter[Offer]
-		GetOffer(ctx context.Context, id string, params ...GetOfferParams) (*Offer, error)
+		UpdateOfferPassenger(ctx context.Context, offerRequestID, passengerID string, input PassengerUpdateInput, requestOptions ...RequestOption) (*OfferRequestPassenger, error)
+		ListOffers(ctx context.Context, offerRequestID string, options []ListOffersParams, requestOptions ...RequestOption) *Iter[Offer]
+		GetOffer(ctx context.Context, offerID string, params []GetOfferParams, requestOptions ...RequestOption) (*Offer, error)
 	}
 
 	Offer struct {
@@ -95,34 +93,41 @@ const (
 )
 
 // UpdateOfferPassenger updates a single offer passenger.
-func (a *API) UpdateOfferPassenger(ctx context.Context, offerRequestID, passengerID string, input PassengerUpdateInput) (*OfferRequestPassenger, error) {
+func (a *API) UpdateOfferPassenger(ctx context.Context, offerRequestID, passengerID string, input PassengerUpdateInput, requestOptions ...RequestOption) (*OfferRequestPassenger, error) {
+	if err := validateID(offerRequestID, offerRequestIDPrefix); err != nil {
+		return nil, err
+	}
+
 	url := fmt.Sprintf("/air/offers/%s/passengers/%s", offerRequestID, passengerID)
-	return newRequestWithAPI[PassengerUpdateInput, OfferRequestPassenger](a).Patch(url, &input).Single(ctx)
+	return newRequestWithAPI[PassengerUpdateInput, OfferRequestPassenger](a).
+		Patch(url, &input).
+		WithOptions(requestOptions...).
+		Single(ctx)
 }
 
 // ListOffers lists all the offers for an offer request. Returns an iterator.
-func (a *API) ListOffers(ctx context.Context, offerRequestID string, options ...ListOffersParams) *Iter[Offer] {
-	if offerRequestID == "" {
-		return ErrIter[Offer](fmt.Errorf("offerRequestId param is required"))
-	} else if !strings.HasPrefix(offerRequestID, offerRequestIDPrefix) {
-		return ErrIter[Offer](fmt.Errorf("offerRequestId should begin with %s", offerRequestIDPrefix))
+func (a *API) ListOffers(ctx context.Context, offerRequestID string, options []ListOffersParams, requestOptions ...RequestOption) *Iter[Offer] {
+	if err := validateID(offerRequestID, offerRequestIDPrefix); err != nil {
+		return ErrIter[Offer](err)
 	}
 
 	return newRequestWithAPI[ListOffersParams, Offer](a).Get("/air/offers").
 		WithParam("offer_request_id", offerRequestID).
 		WithParams(normalizeParams(options)...).
+		WithOptions(requestOptions...).
 		Iter(ctx)
 }
 
 // GetOffer gets a single offer by ID.
-func (a *API) GetOffer(ctx context.Context, offerID string, params ...GetOfferParams) (*Offer, error) {
-	if !strings.HasPrefix(offerID, offerIDPrefix) {
-		return nil, fmt.Errorf("offerID should begin with %s", offerIDPrefix)
+func (a *API) GetOffer(ctx context.Context, offerID string, params []GetOfferParams, requestOptions ...RequestOption) (*Offer, error) {
+	if err := validateID(offerID, offerIDPrefix); err != nil {
+		return nil, err
 	}
 
 	return newRequestWithAPI[GetOfferParams, Offer](a).
 		Getf("/air/offers/%s", offerID).
 		WithParams(normalizeParams(params)...).
+		WithOptions(requestOptions...).
 		Single(ctx)
 }
 
@@ -152,6 +157,7 @@ func (o *Offer) BaseAmount() currency.Amount {
 	}
 	return amount
 }
+
 func (o *Offer) TotalAmount() currency.Amount {
 	amount, err := currency.NewAmount(o.RawTotalAmount, o.RawTotalCurrency)
 	if err != nil {

--- a/offers_test.go
+++ b/offers_test.go
@@ -31,9 +31,11 @@ func TestListOffers(t *testing.T) {
 	ctx := context.TODO()
 
 	client := New("duffel_test_123")
-	iter := client.ListOffers(ctx, "orq_00009htyDGjIfajdNBZRlw", ListOffersParams{
-		Sort:           ListOffersSortTotalAmount,
-		MaxConnections: 1,
+	iter := client.ListOffers(ctx, "orq_00009htyDGjIfajdNBZRlw", []ListOffersParams{
+		{
+			Sort:           ListOffersSortTotalAmount,
+			MaxConnections: 1,
+		},
 	})
 
 	iter.Next()
@@ -64,8 +66,10 @@ func TestGetOfferByID(t *testing.T) {
 	ctx := context.TODO()
 
 	client := New("duffel_test_123")
-	data, err := client.GetOffer(ctx, "off_00009htYpSCXrwaB9DnUm0", GetOfferParams{
-		ReturnAvailableServices: true,
+	data, err := client.GetOffer(ctx, "off_00009htYpSCXrwaB9DnUm0", []GetOfferParams{
+		{
+			ReturnAvailableServices: true,
+		},
 	})
 	a.NoError(err)
 	a.NotNil(data)
@@ -119,9 +123,11 @@ func TestListOffers_InavlidID(t *testing.T) {
 	ctx := context.TODO()
 
 	client := New("duffel_test_123")
-	iter := client.ListOffers(ctx, "fake-id", ListOffersParams{
-		Sort:           ListOffersSortTotalAmount,
-		MaxConnections: 1,
+	iter := client.ListOffers(ctx, "fake-id", []ListOffersParams{
+		{
+			Sort:           ListOffersSortTotalAmount,
+			MaxConnections: 1,
+		},
 	})
 
 	iter.Next()

--- a/offers_test.go
+++ b/offers_test.go
@@ -118,7 +118,7 @@ func TestUpdateOffserPassenger(t *testing.T) {
 	a.Len(data.LoyaltyProgrammeAccounts, 1)
 }
 
-func TestListOffers_InavlidID(t *testing.T) {
+func TestListOffers_InvalidID(t *testing.T) {
 	a := assert.New(t)
 	ctx := context.TODO()
 
@@ -134,6 +134,6 @@ func TestListOffers_InavlidID(t *testing.T) {
 	data := iter.Current()
 	err := iter.Err()
 
-	a.EqualError(err, "offerRequestId should begin with orq_")
+	a.EqualError(err, "id should begin with orq_, but got fake-id")
 	a.Nil(data)
 }

--- a/orders_test.go
+++ b/orders_test.go
@@ -128,8 +128,10 @@ func TestListOrders(t *testing.T) {
 
 	ctx := context.TODO()
 	client := New("duffel_test_123")
-	iter := client.ListOrders(ctx, ListOrdersParams{
-		BookingReference: "RZPNX8",
+	iter := client.ListOrders(ctx, []ListOrdersParams{
+		{
+			BookingReference: "RZPNX8",
+		},
 	})
 
 	iter.Next()

--- a/payments.go
+++ b/payments.go
@@ -9,6 +9,10 @@ import (
 )
 
 type (
+	OrderPaymentClient interface {
+		CreatePayment(ctx context.Context, req CreatePaymentRequest, requestOptions ...RequestOption) (*Payment, error)
+	}
+
 	PaymentType string
 
 	Payment struct {
@@ -30,10 +34,6 @@ type (
 		Currency string      `json:"currency"`
 		Type     PaymentType `json:"type"`
 	}
-
-	OrderPaymentClient interface {
-		CreatePayment(ctx context.Context, req CreatePaymentRequest) (*Payment, error)
-	}
 )
 
 const (
@@ -41,8 +41,11 @@ const (
 	PaymentTypeCash    = PaymentType("arc_bsp_cash")
 )
 
-func (a *API) CreatePayment(ctx context.Context, req CreatePaymentRequest) (*Payment, error) {
-	return newRequestWithAPI[CreatePaymentRequest, Payment](a).Post("/air/payments", &req).Single(ctx)
+func (a *API) CreatePayment(ctx context.Context, req CreatePaymentRequest, requestOptions ...RequestOption) (*Payment, error) {
+	return newRequestWithAPI[CreatePaymentRequest, Payment](a).
+		Post("/air/payments", &req).
+		WithOptions(requestOptions...).
+		Single(ctx)
 }
 
 var _ OrderPaymentClient = (*API)(nil)

--- a/places.go
+++ b/places.go
@@ -8,9 +8,9 @@ import "context"
 
 type (
 	PlacesClient interface {
-		PlaceSuggestions(ctx context.Context, query string) ([]*Place, error)
-		Cities(ctx context.Context) *Iter[City]
-		City(ctx context.Context, id string) (*City, error)
+		PlaceSuggestions(ctx context.Context, query string, requestOptions ...RequestOption) ([]*Place, error)
+		Cities(ctx context.Context, requestOptions ...RequestOption) *Iter[City]
+		City(ctx context.Context, id string, requestOptions ...RequestOption) (*City, error)
 	}
 
 	Place struct {
@@ -36,16 +36,24 @@ type (
 const PlaceTypeAirport = "airport"
 const PlaceTypeCity = "city"
 
-func (a *API) PlaceSuggestions(ctx context.Context, query string) ([]*Place, error) {
+func (a *API) PlaceSuggestions(ctx context.Context, query string, requestOptions ...RequestOption) ([]*Place, error) {
 	return newRequestWithAPI[EmptyPayload, Place](a).
-		Get("/places/suggestions").WithParam("query", query).
+		Get("/places/suggestions").
+		WithParam("query", query).
+		WithOptions(requestOptions...).
 		Slice(ctx)
 }
 
-func (a *API) Cities(ctx context.Context) *Iter[City] {
-	return newRequestWithAPI[EmptyPayload, City](a).Get("/air/cities").Iter(ctx)
+func (a *API) Cities(ctx context.Context, requestOptions ...RequestOption) *Iter[City] {
+	return newRequestWithAPI[EmptyPayload, City](a).
+		Get("/air/cities").
+		WithOptions(requestOptions...).
+		Iter(ctx)
 }
 
-func (a *API) City(ctx context.Context, id string) (*City, error) {
-	return newRequestWithAPI[EmptyPayload, City](a).Getf("/air/cities/%s", id).Single(ctx)
+func (a *API) City(ctx context.Context, id string, requestOptions ...RequestOption) (*City, error) {
+	return newRequestWithAPI[EmptyPayload, City](a).
+		Getf("/air/cities/%s", id).
+		WithOptions(requestOptions...).
+		Single(ctx)
 }

--- a/requestbuilder.go
+++ b/requestbuilder.go
@@ -90,6 +90,17 @@ func WithURLParam(key, value string) RequestOption {
 	}
 }
 
+func WithHeaders(headers map[string][]string) RequestOption {
+	return func(req *http.Request) error {
+		for key, values := range headers {
+			for _, headerVal := range values {
+				req.Header.Add(key, headerVal)
+			}
+		}
+		return nil
+	}
+}
+
 // newRequestWithAPI returns a new fluent requst builder for the given API.
 // The input types are the request payload and response payload.
 // For Get requests, the request payload is used to type the URL params.

--- a/seatmaps.go
+++ b/seatmaps.go
@@ -11,6 +11,10 @@ import (
 )
 
 type (
+	SeatmapClient interface {
+		GetSeatmap(ctx context.Context, offerID string, requestOptions ...RequestOption) ([]*Seatmap, error)
+	}
+
 	Seatmap struct {
 		Cabins    []Cabin `json:"cabins"`
 		ID        string  `json:"id"`
@@ -78,12 +82,6 @@ type (
 		// The index of the last row which is overwing, starting from the front of the aircraft.
 		LastRowIndex int `json:"last_row_index"`
 	}
-
-	SeatmapClient interface {
-		// GetSeatmap returns an iterator for the seatmaps of a given Offer.
-		GetSeatmap(ctx context.Context, offerID string) ([]*Seatmap, error)
-		SeatmapForOffer(ctx context.Context, offer Offer) ([]*Seatmap, error)
-	}
 )
 
 const (
@@ -101,14 +99,15 @@ func (e ElementType) String() string {
 	return string(e)
 }
 
-func (a *API) SeatmapForOffer(ctx context.Context, offer Offer) ([]*Seatmap, error) {
-	return a.GetSeatmap(ctx, offer.ID)
-}
+func (a *API) GetSeatmap(ctx context.Context, offerID string, requestOptions ...RequestOption) ([]*Seatmap, error) {
+	if err := validateID(offerID, offerIDPrefix); err != nil {
+		return nil, err
+	}
 
-func (a *API) GetSeatmap(ctx context.Context, offerID string) ([]*Seatmap, error) {
 	return newRequestWithAPI[EmptyPayload, Seatmap](a).
 		Get("/air/seat_maps").
 		WithParam("offer_id", offerID).
+		WithOptions(requestOptions...).
 		Slice(ctx)
 }
 


### PR DESCRIPTION
This PR adds `...RequestOption` to all clients' functions. 
This PR adds `WithHeaders` RequestOption to set up headers manually. Use-case: `x-client-correlation-id` https://duffel.com/docs/api/overview/making-requests/client-correlation-id